### PR TITLE
AssetHelper.cs: change "archipelago.png" to "Archipelago.png"

### DIFF
--- a/RhythmDoctor.Archipelago/Helpers/AssetHelper.cs
+++ b/RhythmDoctor.Archipelago/Helpers/AssetHelper.cs
@@ -7,7 +7,7 @@ internal static class AssetHelper
     internal static class WardIcons
     {
       internal const string TYPE = "WardIcons";
-      internal const string ARCHIPELAGO = "archipelago.png";
+      internal const string ARCHIPELAGO = "Archipelago.png";
     }
   }
 


### PR DESCRIPTION
This fixes an issue on linux, since linux file names are case sensitive

if people would rather the actual file to be renamed instead of me changing this constant, let me know and I can do that