### PR TITLE
Add Linux instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
    [Download and install BepInEx 5.](https://docs.bepinex.dev/v5.4.21/articles/user_guide/installation/index.html)
 
 2. **Run the Game**
-   Launch Rhythm Doctor once to ensure that BepInEx sets up the required folder structure. If you're on Linux, you need to set your Steam launch options to `./run_bepinex.sh "Rhythm Doctor" # %command%`.
+   Launch Rhythm Doctor once to ensure that BepInEx sets up the required folder structure.
+   If you're using Steam on Linux, you need to set your Steam launch options to `./run_bepinex.sh "Rhythm Doctor" # %command%`.
+   If you're using the itch.io version on Linux, you need to run the game with `./run_bepinex.sh "Rhythm Doctor"`. (Make sure you're in the Rhythm Doctor game installation directory when running this!)
 
 3. **Install the RhythmDoctor.Archipelago plugin**
    - Obtain the mod files from a stable release in the `Releases` section or from GitHub Actions (these are debug builds and may be unstable).
@@ -25,7 +27,7 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
 4. Install **dependencies**
    Obtain and install [Pulse](https://github.com/nonperforming/Pulse) from [its releases page](https://github.com/nonperforming/Pulse/releases)
 
-5. (Linux Only) **Configure BepInEx**
+5. **Configure BepInEx**
    In the `Rhythm Doctor/BepInEx/config/BepInEx.cfg` file, set `HideManagerGameObject` to `true`. The option should be on line 17.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
    [Download and install BepInEx 5.](https://docs.bepinex.dev/v5.4.21/articles/user_guide/installation/index.html)
 
 2. **Run the Game**
-   Launch Rhythm Doctor once to ensure that BepInEx sets up the required folder structure.
+   Launch Rhythm Doctor once to ensure that BepInEx sets up the required folder structure. If you're on Linux, you need to set your Steam launch options to `./run_bepinex.sh "Rhythm Doctor" # %command%`.
 
 3. **Install the RhythmDoctor.Archipelago plugin**
    - Obtain the mod files from a stable release in the `Releases` section or from GitHub Actions (these are debug builds and may be unstable).
@@ -22,13 +22,10 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
       - `Assets` folder
       - `Archipelago.MultiClient.Net.dll`
 
-5. Install **dependencies**
+4. Install **dependencies**
    Obtain and install [Pulse](https://github.com/nonperforming/Pulse) from [its releases page](https://github.com/nonperforming/Pulse/releases)
 
-6. (Linux) **Setup Steam launch options**
-   Set your Steam launch options to `./run_bepinex.sh "Rhythm Doctor" # %command%`. This is required for BepInEx to be able to run.
-
-7. (Linux) **Configure BepInEx**
+5. (Linux Only) **Configure BepInEx**
    In the `Rhythm Doctor/BepInEx/config/BepInEx.cfg` file, set `HideManagerGameObject` to `true`. The option should be on line 17.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
 
 3. **Install the RhythmDoctor.Archipelago plugin**
    - Obtain the mod files from a stable release in the `Releases` section or from GitHub Actions (these are debug builds and may be unstable).
-   - Place the following files in the `Rhythm Doctor\BepInEx\plugins` folder:
+   - Place the following files in the `Rhythm Doctor/BepInEx/plugins` folder:
       - `RhythmDoctor.Archipelago.dll`
       - `io.github.nonperforming.pulse.dll`
       - `Assets` folder
@@ -24,6 +24,12 @@ To set up the Rhythm Doctor Archipelago mod, follow these steps:
 
 5. Install **dependencies**
    Obtain and install [Pulse](https://github.com/nonperforming/Pulse) from [its releases page](https://github.com/nonperforming/Pulse/releases)
+
+6. (Linux) **Setup Steam launch options**
+   Set your Steam launch options to `./run_bepinex.sh "Rhythm Doctor" # %command%`. This is required for BepInEx to be able to run.
+
+7. (Linux) **Configure BepInEx**
+   In the `Rhythm Doctor/BepInEx/config/BepInEx.cfg` file, set `HideManagerGameObject` to `true`. The option should be on line 17.
 
 ## Development
 


### PR DESCRIPTION
note: for some reason the plugin instance seems to get destroyed if `HideManagerGameObject` is set to `false` on Linux. not sure why that's happening, but enabling this setting doesn't seem to cause any side effects so hopefully it's fine.

also I'm not the best at professionally wording things so feel free to change the wording if necessary